### PR TITLE
handle aliases on YAML load

### DIFF
--- a/lib/sm_app_config/app_config.rb
+++ b/lib/sm_app_config/app_config.rb
@@ -21,7 +21,11 @@ class AppConfig
   def self.config
     @config ||= begin
       raw_config = File.read(config_file)
-      loaded = YAML.load(raw_config)
+      loaded = begin
+        YAML.load(raw_config, aliases: true) || {}
+      rescue ArgumentError
+        YAML.load(raw_config) || {}
+      end
 
       if defined?(Rails)
         loaded[Rails.env] or raise "No configuration found for environment #{Rails.env}"


### PR DESCRIPTION
In ruby 3.1.2 Psych 4 load in safe mode by default: https://github.com/ruby/psych/pull/487

So aliases need to be explicitly allowed.